### PR TITLE
Add chaining feature. Refactoring. Add code style and analyzer. Rename some methods.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+# All files
+[*]
+indent_style = space
+
+# Code files
+[*.cs]
+indent_size = 4
+insert_final_newline = false
+
+# Organize usings
+dotnet_sort_system_directives_first = true
+
+# StyleCop
+dotnet_diagnostic.SA1101.severity = none # disable this prefixing
+dotnet_diagnostic.SA1200.severity = none # disable using directives inside
+dotnet_diagnostic.SA1600.severity = none # disable xml documentation check (TODO: need to be fixed)
+dotnet_diagnostic.SA1601.severity = none # disable xml documentation check (TODO: need to be fixed)
+dotnet_diagnostic.SA1633.severity = none # disable file header requirement

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![HTML](/HTML.png "LOGO")
 
-Tool to build an HTML DOM in C# and export it to a string or to an IHtmlContent Enumerable. 
+Package to build an HTML DOM in C# and export it to a `string` or `HtmlContentBuilder`. 
 
 ## Installation 
 
@@ -15,35 +15,78 @@ Nuget package: https://www.nuget.org/packages/Holoon.HtmlBuilder/
 ## Usage
 
 ```c#
+// Method 1 (instances)
 var root = Html.Div();
-
 var h1 = Html.Heading(1);
-h1.AddChild(Html.TextBloc("Hello World !"));
+h1.AddChild(Html.TextBlock("Hello World!"));
 root.AddChild(h1);
-
 var paragraph = Html.Paragraph();
-var ul = Html.BulletList();
+var ul = Html.UnorderedList();
 var li = Html.ListItem();
-paragraph.AddChild(ul);
 ul.AddChild(li);
-li.AddChild(Html.TextBloc("This is a first test."));
+li.AddChild(Html.TextBlock("This is a first test."));
+paragraph.AddChild(ul);
+var ol = Html.OrderedList();
+ol.AddChild(li);
+paragraph.AddChild(ol);
 root.AddChild(paragraph);
-
 root.AddChild(Html.HorizontalRule());
-
-root.AddChild(Html.TextBloc("This is a second test.", new InlineTag("strong", KeyValuePair.Create("class", "second"))));
-
+root.AddChild(Html.LineBreak());
+root.AddChild(Html.TextBlock("This is a second test.",
+    new InlineTag("strong", KeyValuePair.Create("class", "second"))));
+var span = Html.Span();
+span.AddChild(Html.TextBlock("Text is third test."));
+span.AddChild(Html.TextBlock("Text is third test.").SetText("This is fourth test."));
+root.AddChild(span);
 var html = root.ToString();
-/* html:
+
+// Method 2 (chaining)
+var rootChain = Html.Div()
+    .AddChild(
+        Html.Heading(1).AddChild(Html.TextBlock("Hello World!"))
+    ).AddChild(
+        Html.Paragraph()
+            .AddChild(
+                Html.UnorderedList().AddChild(Html.ListItem().AddChild(Html.TextBlock("This is a first test.")))
+            ).AddChild(
+                Html.OrderedList().AddChild(Html.ListItem().AddChild(Html.TextBlock("This is a first test.")))
+            )
+    ).AddChild(
+        Html.HorizontalRule()
+    ).AddChild(
+        Html.LineBreak()
+    ).AddChild(
+        Html.TextBlock("This is a second test.", new InlineTag("strong", KeyValuePair.Create("class", "second"))
+        ).AddChild(
+            Html.Span()
+                .AddChild(
+                    Html.TextBlock("Text is third test.")
+                ).AddChild(
+                    Html.TextBlock("Text is third test.").SetText("This is fourth test.")
+                )
+        )
+    );
+
+var htmlChain = rootChain.ToString();
+
+Console.Write(html);
+Console.Write(htmlChain);
+
+/* rendered html for both methods (formatted manually):
 <div>
-    <h1>Hello World !</h1>
+    <h1>Hello World!</h1>
     <p>
         <ul>
             <li>This is a first test.</li>
         </ul>
+        <ol>
+            <li>This is a first test.</li>
+        </ol>
     </p>
     <hr />
+    <br />
     <strong class="second">This is a second test.</strong>
+    <span>Text is third test.This is fourth test.</span>
 </div>
 */
 ```

--- a/src/HtmlBuilder.Example/Program.cs
+++ b/src/HtmlBuilder.Example/Program.cs
@@ -2,12 +2,11 @@
 using System.Collections.Generic;
 using HtmlBuilder;
 
+// Method 1 (instances)
 var root = Html.Div();
-
 var h1 = Html.Heading(1);
 h1.AddChild(Html.TextBlock("Hello World!"));
 root.AddChild(h1);
-
 var paragraph = Html.Paragraph();
 var ul = Html.UnorderedList();
 var li = Html.ListItem();
@@ -18,21 +17,18 @@ var ol = Html.OrderedList();
 ol.AddChild(li);
 paragraph.AddChild(ol);
 root.AddChild(paragraph);
-
 root.AddChild(Html.HorizontalRule());
 root.AddChild(Html.LineBreak());
-
 root.AddChild(Html.TextBlock("This is a second test.",
     new InlineTag("strong", KeyValuePair.Create("class", "second"))));
-
 var span = Html.Span();
 span.AddChild(Html.TextBlock("Text is third test."));
 span.AddChild(Html.TextBlock("Text is third test.").SetText("This is fourth test."));
 root.AddChild(span);
-
 var html = root.ToString();
 
-root = Html.Div()
+// Method 2 (chaining)
+var rootChain = Html.Div()
     .AddChild(
         Html.Heading(1).AddChild(Html.TextBlock("Hello World!"))
     ).AddChild(
@@ -58,22 +54,25 @@ root = Html.Div()
         )
     );
 
-var htmlChain = root.ToString();
+var htmlChain = rootChain.ToString();
 
 Console.Write(html);
 Console.Write(htmlChain);
 
-/* rendered html for both methods:
+/* rendered html for both methods (formatted manually):
 <div>
     <h1>Hello World!</h1>
     <p>
-    <ul>
-        <li>This is a first test.</li>
-    </ul>
-    <ol>
-        <li>This is a first test.</li>
-    </ol>
+        <ul>
+            <li>This is a first test.</li>
+        </ul>
+        <ol>
+            <li>This is a first test.</li>
+        </ol>
     </p>
-    <hr /><br /><strong class="second">This is a second test.</strong><span>Text is third test.This is fourth test.</span>
+    <hr />
+    <br />
+    <strong class="second">This is a second test.</strong>
+    <span>Text is third test.This is fourth test.</span>
 </div>
 */

--- a/src/HtmlBuilder.Example/Program.cs
+++ b/src/HtmlBuilder.Example/Program.cs
@@ -1,44 +1,76 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using HtmlBuilder;
 
-namespace HtmlBuilder.Example;
+var root = Html.Div();
 
-static class Program
-{
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Unused parameter", Justification = "Exemple class")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0059:Useless assignation", Justification = "Exemple class")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1481:Unused local variables should be removed", Justification = "Exemple class")]
-    static void Main(string[] args)
-    {
-        var root = Html.Div();
+var h1 = Html.Heading(1);
+h1.AddChild(Html.TextBlock("Hello World!"));
+root.AddChild(h1);
 
-        var h1 = Html.Heading(1);
-        h1.AddChild(Html.TextBlock("Hello World !"));
-        root.AddChild(h1);
+var paragraph = Html.Paragraph();
+var ul = Html.UnorderedList();
+var li = Html.ListItem();
+ul.AddChild(li);
+li.AddChild(Html.TextBlock("This is a first test."));
+paragraph.AddChild(ul);
+var ol = Html.OrderedList();
+ol.AddChild(li);
+paragraph.AddChild(ol);
+root.AddChild(paragraph);
 
-        var paragraph = Html.Paragraph();
-        var ul = Html.BulletList();
-        var li = Html.ListItem();
-        paragraph.AddChild(ul);
-        ul.AddChild(li);
-        li.AddChild(Html.TextBlock("This is a first test."));
-        root.AddChild(paragraph);
+root.AddChild(Html.HorizontalRule());
+root.AddChild(Html.LineBreak());
 
-        root.AddChild(Html.HorizontalRule());
+root.AddChild(Html.TextBlock("This is a second test.",
+    new InlineTag("strong", KeyValuePair.Create("class", "second"))));
 
-        root.AddChild(Html.TextBlock("This is a second test.", new InlineTag("strong", KeyValuePair.Create("class", "second"))));
+var span = Html.Span();
+span.AddChild(Html.TextBlock("Text is third test."));
+root.AddChild(span);
 
-        var html = root.ToString();
-        /* html:
-        <div>
-            <h1>Hello World !</h1>
-            <p>
-                <ul>
-                    <li>This is a first test.</li>
-                </ul>
-            </p>
-            <hr />
-            <strong class="second">This is a second test.</strong>
-        </div>
-        */
-    }
-}
+var html = root.ToString();
+
+root = Html.Div()
+    .AddChild(
+        Html.Heading(1).AddChild(Html.TextBlock("Hello World!"))
+    ).AddChild(
+        Html.Paragraph()
+            .AddChild(
+                Html.UnorderedList().AddChild(Html.ListItem().AddChild(Html.TextBlock("This is a first test.")))
+            ).AddChild(
+                Html.OrderedList().AddChild(Html.ListItem().AddChild(Html.TextBlock("This is a first test.")))
+            )
+    ).AddChild(
+        Html.HorizontalRule()
+    ).AddChild(
+        Html.LineBreak()
+    ).AddChild(
+        Html.TextBlock("This is a second test.", new InlineTag("strong", KeyValuePair.Create("class", "second"))
+        ).AddChild(
+            Html.Span()
+                .AddChild(
+                    Html.TextBlock("Text is third test.")
+                )
+        )
+    );
+
+var htmlChain = root.ToString();
+
+Console.Write(html);
+Console.Write(htmlChain);
+
+/* rendered html for both methods:
+<div>
+    <h1>Hello World!</h1>
+    <p>
+        <ul>
+            <li>This is a first test.</li>
+        </ul>
+        <ol>
+            <li>This is a first test.</li>
+        </ol>
+    </p>
+    <hr /><br /><strong class="second">This is a second test.</strong><span>Text is third test.</span>
+</div>
+*/

--- a/src/HtmlBuilder.Example/Program.cs
+++ b/src/HtmlBuilder.Example/Program.cs
@@ -27,6 +27,7 @@ root.AddChild(Html.TextBlock("This is a second test.",
 
 var span = Html.Span();
 span.AddChild(Html.TextBlock("Text is third test."));
+span.AddChild(Html.TextBlock("Text is third test.").SetText("This is fourth test."));
 root.AddChild(span);
 
 var html = root.ToString();
@@ -51,6 +52,8 @@ root = Html.Div()
             Html.Span()
                 .AddChild(
                     Html.TextBlock("Text is third test.")
+                ).AddChild(
+                    Html.TextBlock("Text is third test.").SetText("This is fourth test.")
                 )
         )
     );
@@ -64,13 +67,13 @@ Console.Write(htmlChain);
 <div>
     <h1>Hello World!</h1>
     <p>
-        <ul>
-            <li>This is a first test.</li>
-        </ul>
-        <ol>
-            <li>This is a first test.</li>
-        </ol>
+    <ul>
+        <li>This is a first test.</li>
+    </ul>
+    <ol>
+        <li>This is a first test.</li>
+    </ol>
     </p>
-    <hr /><br /><strong class="second">This is a second test.</strong><span>Text is third test.</span>
+    <hr /><br /><strong class="second">This is a second test.</strong><span>Text is third test.This is fourth test.</span>
 </div>
 */

--- a/src/HtmlBuilder/Html.Static.cs
+++ b/src/HtmlBuilder/Html.Static.cs
@@ -1,58 +1,73 @@
-﻿using Microsoft.AspNetCore.Html;
-using Microsoft.AspNetCore.Mvc.Rendering;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace HtmlBuilder;
 
 public partial class Html
 {
     public static Html Paragraph() => EmptyTag("p");
+
     public static Html Div() => EmptyTag("div");
+
     public static Html Span() => EmptyTag("span");
+
     public static Html OrderedList() => EmptyTag("ol");
-    public static Html BulletList() => EmptyTag("ul");
+
+    public static Html UnorderedList() => EmptyTag("ul");
+
     public static Html ListItem() => EmptyTag("li");
+
     public static Html CodeBlock() => EmptyTag("code");
+
     public static Html Blockquote() => EmptyTag("blockquote");
+
     public static Html CustomTag(string tagName, params KeyValuePair<string, string>[] attributes)
     {
         var builder = new TagBuilder(tagName ?? "div");
 
         foreach (var attribute in attributes ?? Array.Empty<KeyValuePair<string, string>>())
+        {
             builder.MergeAttribute(attribute.Key, attribute.Value);
+        }
 
         var tag = new Html(builder);
         return tag;
     }
-    private static Html EmptyTag(string tagName) => CustomTag(tagName);
+
     public static Html HorizontalRule()
     {
         var builder = new TagBuilder("hr");
         var tag = new Html(builder, true);
         return tag;
     }
-    public static Html HardBreak()
+
+    public static Html LineBreak()
     {
         var builder = new TagBuilder("br");
         var tag = new Html(builder, true);
         return tag;
     }
-    public static Html Image(string src, string alt, string title) => CustomTag("img",
+
+    public static Html Image(string src, string alt, string title) => CustomTag(
+        "img",
         KeyValuePair.Create("src", src),
         KeyValuePair.Create("alt", alt),
         KeyValuePair.Create("title", title));
+
     public static Html Heading(int? level) => EmptyTag($"h{level ?? 1}");
+
     public static Html TextBlock(string text, params InlineTag[] inlines)
     {
         var builder = new HtmlContentBuilder();
         var rootTag = new Html(builder);
 
-        Html currentTag = rootTag;
+        var currentTag = rootTag;
         foreach (var inline in inlines ?? Array.Empty<InlineTag>())
         {
-            var childTag = CustomTag(inline?.Tag, inline?.Attributes?.ToArray()); 
+            var childTag = CustomTag(inline?.Tag, inline?.Attributes?.ToArray());
             currentTag.AddChild(childTag);
             currentTag = childTag;
         }
@@ -60,4 +75,6 @@ public partial class Html
         currentTag.SetText(text);
         return rootTag;
     }
+
+    private static Html EmptyTag(string tagName) => CustomTag(tagName);
 }

--- a/src/HtmlBuilder/Html.cs
+++ b/src/HtmlBuilder/Html.cs
@@ -41,13 +41,14 @@ public partial class Html
 
     public Html SetText(string text)
     {
-        if (IsTag && TagBuilder != null)
+        switch (IsTag)
         {
-            _ = TagBuilder.InnerHtml.AppendLine(text);
-        }
-        else if (!IsTag && ContentBuilder != null)
-        {
-            _ = ContentBuilder.AppendLine(text);
+            case true when TagBuilder != null:
+                _ = TagBuilder.InnerHtml.SetContent(text);
+                break;
+            case false when ContentBuilder != null:
+                _ = ContentBuilder.SetContent(text);
+                break;
         }
 
         return this;

--- a/src/HtmlBuilder/Html.cs
+++ b/src/HtmlBuilder/Html.cs
@@ -1,37 +1,56 @@
-﻿using Microsoft.AspNetCore.Html;
-using Microsoft.AspNetCore.Mvc.Rendering;
-using System;
-using System.Linq;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace HtmlBuilder;
 
 public partial class Html
 {
-    internal Html(TagBuilder builder, bool selfClosed = false)
+    private Html(TagBuilder builder, bool selfClosed = false)
     {
         SelfClosed = selfClosed;
         TagBuilder = builder;
         IsTag = true;
     }
-    internal Html(HtmlContentBuilder builder)
+
+    private Html(HtmlContentBuilder builder)
     {
         ContentBuilder = builder;
         IsTag = false;
     }
-    internal bool IsTag { get; }
-    internal bool SelfClosed { get; }
-    internal TagBuilder TagBuilder { get; }
-    internal HtmlContentBuilder ContentBuilder { get; }
-    public IEnumerable<Html> Children { get; } = new List<Html>();
-    public void AddChild(Html child) => ((List<Html>)Children).Add(child);
-    public void SetText(string text)
+
+    private bool IsTag { get; }
+
+    private bool SelfClosed { get; }
+
+    private TagBuilder TagBuilder { get; }
+
+    private HtmlContentBuilder ContentBuilder { get; }
+
+    private IEnumerable<Html> Children { get; } = new List<Html>();
+
+    public Html AddChild(Html child)
+    {
+        ((List<Html>)Children).Add(child);
+
+        return this;
+    }
+
+    public Html SetText(string text)
     {
         if (IsTag && TagBuilder != null)
+        {
             _ = TagBuilder.InnerHtml.AppendLine(text);
+        }
         else if (!IsTag && ContentBuilder != null)
+        {
             _ = ContentBuilder.AppendLine(text);
+        }
+
+        return this;
     }
 
     public override string ToString()
@@ -41,17 +60,24 @@ public partial class Html
         writer.Flush();
         return writer.ToString();
     }
+
     public virtual HtmlContentBuilder RenderHtml()
     {
         var builder = new HtmlContentBuilder();
         foreach (var htmlContent in RenderRecursively(this))
+        {
             _ = builder.AppendHtml(htmlContent);
+        }
+
         return builder;
     }
+
     private static IEnumerable<IHtmlContent> RenderRecursively(Html html)
     {
         if (html == null)
+        {
             yield break;
+        }
 
         if (html.IsTag && html.TagBuilder != null)
         {
@@ -72,10 +98,14 @@ public partial class Html
         foreach (var child in html.Children ?? Array.Empty<Html>())
         {
             foreach (var htmlContent in RenderRecursively(child))
+            {
                 yield return htmlContent;
+            }
         }
 
         if (html.IsTag && html.TagBuilder != null)
+        {
             yield return html.TagBuilder.RenderEndTag();
+        }
     }
 }

--- a/src/HtmlBuilder/HtmlBuilder.csproj
+++ b/src/HtmlBuilder/HtmlBuilder.csproj
@@ -16,6 +16,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/HtmlBuilder/HtmlBuilder.csproj
+++ b/src/HtmlBuilder/HtmlBuilder.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/Holoon/HtmlBuilder</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <PackageTags>Html C# .NET</PackageTags>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HtmlBuilder/InlineTag.cs
+++ b/src/HtmlBuilder/InlineTag.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 namespace HtmlBuilder;
 
@@ -8,14 +7,10 @@ public class InlineTag
     public InlineTag(string tag, params KeyValuePair<string, string>[] attributes)
     {
         Tag = tag;
-        if (attributes != null && attributes.Any())
-        {
-            var dictionary = new Dictionary<string, string>();
-            foreach (var attribute in attributes)
-                dictionary.Add(attribute.Key, attribute.Value);
-            Attributes = attributes;
-        }
+        Attributes = attributes;
     }
+
     public string Tag { get; set; }
+
     public IEnumerable<KeyValuePair<string, string>> Attributes { get; set; }
 }


### PR DESCRIPTION
Changes:
- Change return type in `AddChild` and `SetText` - this will allow to chain methods on `Html` instance
- Renamed `BulletList` to `UnorderedList` (according [mdn](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul))
- Renamed `HardBread` to `LineBreak` (according [mdn](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br))
- Fixed `\r\n` issue in `SetText`, which was appending new line (i.g. element) and not setting text (which is a method named)
- Changed access modifier on `Html` ctor
- Added StyleCop analyzer and code formatting `.editorconfig` (contain code style and analyzer rules).
- Updated example project (with additions of elements)
- Updated README.md
- Increased package version

Shortly: breaking change (method rename), bugfix, feature implementation.

p.s.: used in real project, found chaining useful, so decided to support this project.

p.s.s.: consider downgrade to `netstandard2.0` so package can be used in .net framework >4.6.1