### PR TITLE
Upgrade to .Net 8 and replace deprecated package by framework reference

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '8.0.x'
 
       - name: Install dependencies
         run: dotnet restore HtmlBuilder.sln -s https://api.nuget.org/v3/index.json

--- a/src/HtmlBuilder.Example/HtmlBuilder.Example.csproj
+++ b/src/HtmlBuilder.Example/HtmlBuilder.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HtmlBuilder/HtmlBuilder.csproj
+++ b/src/HtmlBuilder/HtmlBuilder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageId>Holoon.HtmlBuilder</PackageId>
     <Authors>Xavier</Authors>
     <Company>Holoon</Company>
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Upgrades the target framework to .Net 8. Not .Net 9, because .Net 8 is an LTS release, but I'm open to changing it to .Net 9
- Replaces the deprecated package `Microsoft.AspNetCore.Mvc.ViewFeatures` by a framework reference that now contains the necessary classes (`TagBuilder` and `HtmlBuilder`); this fixes NuGet warnings about vulnerabilities in dependencies.

When this is merged and released, I'll upgrade https://github.com/Holoon/ProseMirror.Model as well.